### PR TITLE
Fixed release workflow

### DIFF
--- a/.github/workflows/release_droid_upload_github_release_assets.yml
+++ b/.github/workflows/release_droid_upload_github_release_assets.yml
@@ -9,9 +9,7 @@ on:
 
 jobs:
   check-release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/check_precommit.yaml
+    uses: ./.github/workflows/check_precommit.yaml
 
   integration_tests:
     strategy:


### PR DESCRIPTION
I misunderstood the documentation for reusable workflows the first time. If you import a workflow, you do it on the job level and not the step level. On the step level, you only can import composite actions.
https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow
https://docs.github.com/en/actions/creating-actions/creating-a-composite-action