### PR TITLE
Fix check release in GH workflow

### DIFF
--- a/.github/workflows/release_droid_upload_github_release_assets.yml
+++ b/.github/workflows/release_droid_upload_github_release_assets.yml
@@ -9,9 +9,7 @@ on:
 
 jobs:
   check-release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/check_precommit.yaml
+    uses: ./.github/workflows/check_precommit.yaml
 
   integration_tests:
     strategy:

--- a/.github/workflows/release_droid_upload_github_release_assets.yml
+++ b/.github/workflows/release_droid_upload_github_release_assets.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   check-release:
-    uses: ./.github/workflows/check_precommit.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/check_precommit.yaml
 
   integration_tests:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
         pass_filenames: false
         always_run: true
         entry: githooks/update_setup_py.sh
-      - id: update_setup_py
-        name: Update setup.py
+      - id: prohibit_push_to_main
+        name: prohibit push to main
         language: system
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,6 @@ repos:
         language: system
         types: [ shell ]
         entry: shellcheck -x
-      - id: prohibit_commit_to_main
-        name: Prohibit commits to local main branch
-        language: system
-        pass_filenames: false
-        always_run: true
-        entry: githooks/prohibit_commit_to_main.sh
       - id: update_setup_py
         name: Update setup.py
         language: system


### PR DESCRIPTION
- Removed prohibit_commit_to_main pre-commit hook to be able to use pre-commit for release check