### PR TITLE
Fix push_pages_release nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import nox
 
 from scripts.release import release_project
-from scripts.version_check import check_or_fix_version
+from scripts.version_check import check_or_fix_version, version_from_poetry
 
 PROJECT_ROOT = Path(__file__).parent
 LOCAL_DOC = PROJECT_ROOT / "doc"
@@ -116,15 +116,17 @@ def push_pages_current(session: nox.Session):
 @nox.session(name="push-pages-release", python=False)
 def push_pages_release(session: nox.Session):
     """Generate the GitHub pages documentation for the release and pushes it to the remote branch github-pages/main"""
-    tags = session.run("git", "tag", "--sort=committerdate", silent=True)
-    # get the latest tag. last element in list is empty string, so choose second to last
-    tag = tags.split("\n")[-2]
+
+    version = version_from_poetry()
+    version_string = f"{version.major}.{version.minor}.{version.patch}"
+    session.run("git", "tag", version_string)
+    session.run("git", "push", "origin", version_string)
     with session.chdir(PROJECT_ROOT):
         session.run("sgpg",
                     "--target-branch", "github-pages/main",
                     "--push-origin", "origin",
                     "--push",
-                    "--source-branch", tag,
+                    "--source-branch", version_string,
                     "--source_origin", "tags",
                     "--module-path", "${StringArray[@]}",
                     env={"StringArray": (f"../{Settings.PORJECT_NAME}")})


### PR DESCRIPTION
The previous method didn't work, because release-droid doesn't create tags.